### PR TITLE
Added the elastic machine group

### DIFF
--- a/wind_tunnel/submit_tasks.py
+++ b/wind_tunnel/submit_tasks.py
@@ -31,7 +31,7 @@ flags.DEFINE_enum("resolution", "low", ["low", "medium", "high"],
 flags.DEFINE_string("machine_type", "c2-standard-16", "Machine type.")
 flags.DEFINE_integer("num_machines", 1, "Number of machines.")
 flags.DEFINE_integer("disk_size_gb", 60, "Disk size in GB.")
-flags.DEFINE_boolean("elastic_machine_group", False,
+flags.DEFINE_boolean("elastic_machine_group", True,
                      "Whether to use an elastic machine group.")
 
 flags.DEFINE_string("output_dataset", None, "Path to the output dataset.")


### PR DESCRIPTION
Adds the option to use an elastic machine group to the `submit_tasks.py` script.

## Testing

Tested with the elastic machine groups and the script works as expected.
Tested the monitor tasks and the script also works. Additionally we can shut down the machine groups without any issues.

The machine groups seem to scale as expected:

![image](https://github.com/inductiva/datasets-generation/assets/33664950/b292ae10-13a2-43c6-b9b9-eeab0098c286)
